### PR TITLE
Smooth wheels

### DIFF
--- a/timeout_frontend/app/app.js
+++ b/timeout_frontend/app/app.js
@@ -1,12 +1,15 @@
 import React, { Component } from 'react';
 import AppDefault from './app.css';
 import YearTimer from './components/year_timer';
+import RollingSmooth from './components/rolling_smooth';
 
 class App extends Component {
   render() {
     return (
       <AppDefault>
         <YearTimer date={new Date()} />
+        <br /><br /><br /><br />
+        <RollingSmooth value={3} min={2} max={7} secondPerAnim={3} reverse />
       </AppDefault>
     );
   }

--- a/timeout_frontend/app/components/digit_roller.js
+++ b/timeout_frontend/app/components/digit_roller.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import RollingDigit from './rolling_digit';
+import RollingSmooth from './rolling_smooth';
 
 export default class DigitRoller extends Component {
   constructor(props) {
@@ -10,6 +11,7 @@ export default class DigitRoller extends Component {
     this.tick = this.tick.bind(this);
   }
   componentDidMount() {
+    if (this.props.smooth) return;
     if (this.props.secondPer * 1000 > 2147483647) return;
     const { initDelay, secondPer } = this.props;
     this.timer = setInterval(this.tick, (initDelay || secondPer) * 1000);
@@ -33,29 +35,40 @@ export default class DigitRoller extends Component {
     startValue: ?number;
     initDelay: ?number;
     reverse: ?boolean;
+    smooth: ?boolean;
   };
 
   render() {
-    const { initDelay, secondPer, reverse } = this.props;
+    const { initDelay, secondPer, reverse, smooth } = this.props;
     const safeSecondPer = (secondPer * 1000 > 2147483647) ? Infinity : secondPer;
     const safeInitDelay = initDelay || Infinity;
 
     // after the first tick(), set the timer roll to the steady interval
-    if (!this.afterFirst && this.state.alt && this.timer) {
+    if (!this.afterFirst && this.state.alt && this.timer && !smooth) {
       this.afterFirst = true;
       clearInterval(this.timer);
       this.timer = setInterval(this.tick, this.props.secondPer * 1000);
     }
 
     return (
-      <RollingDigit
-        min={this.props.min || 0}
-        max={this.props.max || 9}
-        alt={this.state.alt}
-        value={this.state.tick}
-        delay={this.afterFirst ? safeSecondPer - 1 : safeInitDelay - 1}
-        reverse={reverse}
-      />
+      smooth ?
+        <RollingSmooth
+          min={this.props.min || 0}
+          max={this.props.max || 9}
+          alt={this.state.alt}
+          value={this.state.tick}
+          secondPerAnim={secondPer}
+          delay={initDelay}
+          reverse={reverse}
+        /> :
+        <RollingDigit
+          min={this.props.min || 0}
+          max={this.props.max || 9}
+          alt={this.state.alt}
+          value={this.state.tick}
+          delay={this.afterFirst ? safeSecondPer - 1 : safeInitDelay - 1}
+          reverse={reverse}
+        />
     );
   }
 }

--- a/timeout_frontend/app/components/rolling_digit.css.js
+++ b/timeout_frontend/app/components/rolling_digit.css.js
@@ -1,5 +1,5 @@
-import { keyframes } from 'styled-components';
 import React from 'react';
+import { keyframes } from 'styled-components';
 
 const styled = require('styled-components');
 // TODO: SWITCH BACK TO THIS SHIT WHEN WEBPACK FIXES ITSELF
@@ -32,7 +32,7 @@ const one = rollUp();
 const two = rollUp(true);
 
 // create a basic set of style properties for our timer
-const defaultStyle = {
+export const defaultStyle = {
   width: '24px',
   height: '40px',
   padding: '2px 4px',
@@ -44,7 +44,7 @@ const defaultStyle = {
   'vertical-align': 'middle'
 };
 // create a basic set of styles for the container for our rolling digit
-const defaultContainer = {
+export const defaultContainer = {
   overflow: 'hidden',
   width: '28px',
   height: '40px',
@@ -61,8 +61,10 @@ const defaultContainer = {
 * @alt: different className animation to re-render with delays & fresh anim.
 **/
 const RollingDigitDefaults = styled.default.div`${defaultStyle}
-  -webkit-animation: ${props => props.alt ? one : two} ${props => props.secondPerAnim * 1100}ms ease-in-out 1;
-  animation: ${props => props.alt ? one : two} ${props => props.secondPerAnim * 1000}ms ease-in-out 1;
+  -webkit-animation: ${props => props.alt ? one : two}
+    ${props => props.secondPerAnim * 1100}ms ease-in-out 1;
+  animation: ${props => props.alt ? one : two}
+    ${props => props.secondPerAnim * 1000}ms ease-in-out 1;
   -webkit-animation-delay: ${props => props.delay}s;
   animation-delay: ${props => props.delay}s;
   &::after {
@@ -72,7 +74,6 @@ const RollingDigitDefaults = styled.default.div`${defaultStyle}
 const RollingDigitContainerDefaults = styled.default.div`${defaultContainer}`;
 
 
-// holy shitoly this is getting absurd for fixing the namespacing that
-// the webpack-styled-components mismatch created.
+// TODO switch this back when webpack sucks less
 export const RollingDigitDefault = props => <RollingDigitDefaults name="RollingDigitDefault" {...props} />;
 export const RollingDigitContainerDefault = props => <RollingDigitContainerDefaults name="RollingDigitContainerDefault" {...props} />;

--- a/timeout_frontend/app/components/rolling_digit.js
+++ b/timeout_frontend/app/components/rolling_digit.js
@@ -7,28 +7,27 @@ import {
 type Props = {
   min: ?number;
   max: ?number;
-  value: ?number;
-  secondPerAnim: ?number;
-  delay: ?number;
   alt: ?boolean;
+  value: ?number;
+  delay: ?number;
   reverse: ?boolean;
+  secondPerAnim: ?number;
 };
 
 export default function RollingDigit(props: Props) {
   const {
-    min,
-    max,
-    alt,
-    value,
+    max = 9,
+    min = 0,
+    delay = 0,
+    value = min,
+    secondPerAnim = 1,
     reverse,
-    secondPerAnim,
-    delay
+    alt
   } = props;
 
-  const safeValue = value || min || 0;
-  let nextValue = (safeValue + 1 > max) ? min || 0 : safeValue + 1;
-  if (reverse) nextValue = (safeValue - 1 < min) ? max : safeValue - 1;
-  const safeSpeed = (delay === Infinity) ? Infinity : secondPerAnim || 1;
+  let nextValue = (value + 1 > max) ? min : value + 1;
+  if (reverse) nextValue = (value - 1 < min) ? max : value - 1;
+  const safeSpeed = (delay === Infinity) ? Infinity : secondPerAnim;
   return (
     <RollingDigitContainerDefault>
       <RollingDigitDefault
@@ -37,7 +36,7 @@ export default function RollingDigit(props: Props) {
         secondPerAnim={safeSpeed}
         alt={alt}
       >
-        {safeValue}
+        {value}
       </RollingDigitDefault>
     </RollingDigitContainerDefault>
   );

--- a/timeout_frontend/app/components/rolling_smooth.css.js
+++ b/timeout_frontend/app/components/rolling_smooth.css.js
@@ -9,9 +9,20 @@ const styled = require('styled-components');
 const smoothRollUp = numOfItems => keyframes`
   0% {
     top: 40px;
+    color: rgba(0, 0, 0, 0);
+  }
+  ${50 / numOfItems}% {
+    color: rgba(0, 0, 0, 0);
+  }
+  ${100 / numOfItems}% {
+    color: rgba(0, 0, 0, 1);
+  }
+  ${150 / numOfItems}% {
+    color: rgba(0, 0, 0, 0);
   }
   100% {
     top: -${40 * numOfItems}px;
+    color: rgba(0, 0, 0, 0);
   }
 `;
 

--- a/timeout_frontend/app/components/rolling_smooth.css.js
+++ b/timeout_frontend/app/components/rolling_smooth.css.js
@@ -39,7 +39,7 @@ const RollingSmoothDefaults = styled.default.div`${props => Object.assign(
   animation-delay: ${props => props.delay}s;
 `;
 const RollingSmoothContainerDefaults = styled.default.div`${props => Object.assign(defaultContainer,
-  { width: `${24 * props.width}px` }
+  { width: `${28 * props.width}px` }
 )}`;
 
 // TODO switch this back when webpack sucks less

--- a/timeout_frontend/app/components/rolling_smooth.css.js
+++ b/timeout_frontend/app/components/rolling_smooth.css.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { keyframes } from 'styled-components';
+import { defaultContainer, defaultStyle } from './rolling_digit.css';
+
+const styled = require('styled-components');
+// TODO: SWITCH BACK TO THIS SHIT WHEN WEBPACK FIXES ITSELF
+// import styled, { keyframes } from 'styled-components';
+
+const smoothRollUp = numOfItems => keyframes`
+  0% {
+    top: 40px;
+  }
+  100% {
+    top: -${40 * numOfItems}px;
+  }
+`;
+
+
+const RollingSmoothDefaults = styled.default.div`${props => Object.assign(
+    defaultStyle,
+    { width: `${24 * props.width}px`, top: '40px' }
+  )}
+  -webkit-animation: ${props => smoothRollUp(props.numOfItems)}
+    ${props => props.secondPerAnim * 1100}ms linear infinite;
+  animation: ${props => smoothRollUp(props.numOfItems)}
+    ${props => props.secondPerAnim * 1000}ms linear infinite;
+  -webkit-animation-delay: ${props => props.delay}s;
+  animation-delay: ${props => props.delay}s;
+`;
+const RollingSmoothContainerDefaults = styled.default.div`${props => Object.assign(defaultContainer,
+  { width: `${24 * props.width}px` }
+)}`;
+
+// TODO switch this back when webpack sucks less
+export const RollingSmoothDefault = props => <RollingSmoothDefaults name="RollingSmoothDefault" {...props} />;
+export const RollingSmoothContainerDefault = props => <RollingSmoothContainerDefaults name="RollingSmoothContainerDefault" {...props} />;

--- a/timeout_frontend/app/components/rolling_smooth.js
+++ b/timeout_frontend/app/components/rolling_smooth.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  RollingSmoothDefault,
+  RollingSmoothContainerDefault
+} from './rolling_smooth.css';
+
+type Props = {
+  min: ?number;
+  max: ?number;
+  value: ?number;
+  delay: ?number;
+  reverse: ?boolean;
+  secondPerAnim: ?number;
+};
+
+export default function RollingSmooth(props: Props) {
+  const {
+    min = 0,
+    delay = 0,
+    value = min,
+    secondPerAnim = 1,
+    reverse,
+    max
+  } = props;
+  let defaultDigits = '0123456789'.split('');
+  defaultDigits = defaultDigits.filter(e => e >= min);
+  if (max) defaultDigits = defaultDigits.filter(e => e <= max);
+  if (reverse) defaultDigits = defaultDigits.reverse();
+  const valIndex = defaultDigits.findIndex(e => parseInt(e, 10) === value);
+
+  return (
+    <RollingSmoothContainerDefault>
+      {defaultDigits.map((digit, i) =>
+        <RollingSmoothDefault
+          key={i}
+          width={digit.length}
+          delay={delay - ((valIndex + i) * secondPerAnim)}
+          numOfItems={defaultDigits.length}
+          secondPerAnim={secondPerAnim * defaultDigits.length}
+        >
+          {digit}
+        </RollingSmoothDefault>
+      )}
+    </RollingSmoothContainerDefault>
+  );
+}

--- a/timeout_frontend/app/components/rolling_smooth.js
+++ b/timeout_frontend/app/components/rolling_smooth.js
@@ -29,7 +29,7 @@ export default function RollingSmooth(props: Props) {
   const valIndex = defaultDigits.findIndex(e => parseInt(e, 10) === value);
 
   return (
-    <RollingSmoothContainerDefault>
+    <RollingSmoothContainerDefault width={defaultDigits[0].length}>
       {defaultDigits.map((digit, i) =>
         <RollingSmoothDefault
           key={i}

--- a/timeout_frontend/app/components/year_timer.js
+++ b/timeout_frontend/app/components/year_timer.js
@@ -129,13 +129,14 @@ class YearTimer extends Component {
           secondPer={10}
           startValue={second[0]}
           initDelay={tensecondOffset}
+          smooth
           reverse
         />
         <DigitRoller
           secondPer={1}
           startValue={second[1]}
           initDelay={secondOffset}
-          reverse
+          smooth
         />
       </TimerWrapperDefault>
     );

--- a/timeout_frontend/test/app/components/digit_roller_test.js
+++ b/timeout_frontend/test/app/components/digit_roller_test.js
@@ -101,4 +101,28 @@ describe('<DigitRoller />', () => {
     expect(wrapper.children().at(0).props().children).to.eql(3);
     expect(wrapper.children().at(0).props().nextValue).to.eql(6);
   });
+
+  it('can roll smoothly instead', () => {
+    const wrapper = mount(<DigitRoller min={3} secondPer={4} initDelay={0.3} smooth />);
+    expect(wrapper.find('RollingSmoothDefault').length).to.eql(7);
+    expect(wrapper.find('RollingSmoothDefault').at(0).props()).to.eql({
+      children: '3',
+      delay: 0.3,
+      numOfItems: 7,
+      secondPerAnim: 28,
+      width: 1
+    });
+    expect(wrapper.find('RollingSmoothDefault').at(1).props()).to.eql({
+      children: '4',
+      delay: -3.7,
+      numOfItems: 7,
+      secondPerAnim: 28,
+      width: 1
+    });
+  });
+
+  it('can doesn\'t need any timers when smooth', () => {
+    const wrapper = mount(<DigitRoller smooth />);
+    expect(wrapper.find('DigitRoller').root.node.timer).to.eql(undefined);
+  });
 });

--- a/timeout_frontend/test/app/components/rolling_smooth_test.js
+++ b/timeout_frontend/test/app/components/rolling_smooth_test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RollingSmooth from '.app/components/rolling_smooth';
+
+describe('<RollingSmooth />', () => {
+  it('renders correctly given minimal props', () => {
+    const wrapper = shallow(<RollingSmooth />);
+    expect(wrapper.find('RollingSmoothContainerDefault').length).to.eql(1);
+    expect(wrapper.find('RollingSmoothDefault').length).to.eql(10);
+    // it starts at 0, given nothing
+    expect(wrapper.find('RollingSmoothDefault').at(0).props()).to.eql({
+      width: 1,
+      delay: 0,
+      numOfItems: 10,
+      secondPerAnim: 10,
+      children: '0'
+    });
+    // it gets a numeral key
+    expect(wrapper.find('RollingSmoothDefault').at(0).key()).to.eql('0');
+    // it ends at 9, given nothing, has a length - 1 * anim delay
+    expect(wrapper.find('RollingSmoothDefault').at(9).props()).to.eql({
+      width: 1,
+      delay: -9,
+      numOfItems: 10,
+      secondPerAnim: 10,
+      children: '9'
+    });
+    expect(wrapper.find('RollingSmoothDefault').at(9).key()).to.eql('9');
+  });
+
+  it('renders listens to min/max props', () => {
+    const wrapper = shallow(<RollingSmooth min={3} max={6} />);
+    expect(wrapper.find('RollingSmoothDefault').length).to.eql(4);
+    expect(wrapper.find('RollingSmoothDefault').at(0).props().children).to.eql('3');
+    expect(wrapper.find('RollingSmoothDefault').at(3).props().children).to.eql('6');
+  });
+
+  it('can do reverse motion', () => {
+    const wrapper = shallow(<RollingSmooth min={3} max={6} reverse />);
+    expect(wrapper.find('RollingSmoothDefault').length).to.eql(4);
+    expect(wrapper.find('RollingSmoothDefault').at(0).props().children).to.eql('6');
+    expect(wrapper.find('RollingSmoothDefault').at(1).props().children).to.eql('5');
+    expect(wrapper.find('RollingSmoothDefault').at(2).props().children).to.eql('4');
+    expect(wrapper.find('RollingSmoothDefault').at(3).props().children).to.eql('3');
+  });
+
+  it('correctly interprets delay and anim timing', () => {
+    const wrapper = shallow(<RollingSmooth min={3} max={6} secondPerAnim={10} />);
+    // anim 40s because it's length * animtime
+    expect(wrapper.find('RollingSmoothDefault').at(0).props()).to.eql({
+      children: '3',
+      delay: 0,
+      numOfItems: 4,
+      secondPerAnim: 40,
+      width: 1
+    });
+    // delay is -30 because it's 3 cycles away, and anim is 10s long
+    expect(wrapper.find('RollingSmoothDefault').at(3).props()).to.eql({
+      children: '6',
+      delay: -30,
+      numOfItems: 4,
+      secondPerAnim: 40,
+      width: 1
+    });
+  });
+
+  it('begins rolling at the correct value', () => {
+    const wrapper = shallow(<RollingSmooth min={3} value={4} delay={0.12} />);
+    expect(wrapper.find('RollingSmoothDefault').at(0).props()).to.eql({
+      children: '3',
+      delay: -0.88,
+      numOfItems: 7,
+      secondPerAnim: 7,
+      width: 1
+    });
+    expect(wrapper.find('RollingSmoothDefault').at(1).props()).to.eql({
+      children: '4',
+      delay: -1.88,
+      numOfItems: 7,
+      secondPerAnim: 7,
+      width: 1
+    });
+  });
+});


### PR DESCRIPTION
Adds a smooth rolling component that is like 5x more stressful to render, but is simpler in a bunch of ways, and will set less component renders when it's integrated into digit-roller.

Also more extensible, it can be opened up to roll past any number of things, anything that can be expressed as an array really.